### PR TITLE
Allow to flatten same logical operations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,8 +126,18 @@ function processNode (node, valueOnly = false) {
 
     case 'LogicalExpression':
     case 'BinaryExpression': {
+      const op = processOp(node.operator);
+      const leftOp = processOp(node.left.operator);
+      const rightOp = processOp(node.right.operator);
+      const left = processNode(node.left);
+      const right = processNode(node.right)
+      if (node.type === 'LogicalExpression') {
+        return {
+          [op]: [...(op === leftOp ? left[leftOp] : [left]), ...(op === rightOp ? right[rightOp] : [right])]
+        }
+      }
       return {
-        [processOp(node.operator)]: [processNode(node.left), processNode(node.right)]
+        [op]: [left, right]
       }
     }
 


### PR DESCRIPTION
**The problem**
Consider having such flat logical expression as a string:
`first === 1 || second === 2 || third === 3`
After transformation to the json logic it will be changed to the tree:
`{"or":[{"or":[{"===":[{"var":"first"},1]},{"===":[{"var":"second"},2]}]},{"===":[{"var":"third"},3]}]}`
So instead of flat structure it will be nested.
Then, if I try to use that structure with [https://github.com/ukrbublik/react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) the result UI will be like this:
![image](https://user-images.githubusercontent.com/24254801/98214666-74f4a680-1f4f-11eb-8b17-c22e63b4459e.png)

**Possible solution**
This PR tries to flatten only logical expression node if it's left or right children are also logical expression with the same operator. Please take a look at the results after applying changes:
`{"or":[{"===":[{"var":"first"},1]},{"===":[{"var":"second"},2]},{"===":[{"var":"third"},3]}]}`
![image](https://user-images.githubusercontent.com/24254801/98215035-f1878500-1f4f-11eb-8b68-0a3f82d15132.png)

**Notes**
This is just an idea and maybe it is completely wrong for complex cases. Also maybe it's ok to have it in options to be able to allow/disable flattening from outside code.
Thank you for the library, it is very useful.