### PR TITLE
Use explicit condition to filter undefined and null instead of Boolea…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ function processNode (node, valueOnly = false) {
           node.alternate
             ? processNode(node.alternate)
             : undefined
-        ].filter(Boolean)
+        ].filter(item => item !== undefined)
       }
     }
 


### PR DESCRIPTION

Boolean constructor filters out `0, '', [] , {},null` while all these are valid json logic expressions.